### PR TITLE
9.0-mig-partner_vat_unique

### DIFF
--- a/partner_vat_unique/README.rst
+++ b/partner_vat_unique/README.rst
@@ -1,0 +1,67 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================
+Partner VAT unique
+==================
+
+Add a constraint on partners so that vat must be unique except
+in partner with parent/child relationship.
+
+Installation
+============
+
+To install this module, you need to:
+
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+
+Usage
+=====
+
+To use this module, you need to:
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.adhoc.com.ar/
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "9.0" for example
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* ADHOC SA: `Icon <http://fotos.subefotos.com/83fed853c1e15a8023b86b2b22d6145bo.png>`_.
+
+Contributors
+------------
+
+
+Maintainer
+----------
+
+.. image:: http://fotos.subefotos.com/83fed853c1e15a8023b86b2b22d6145bo.png
+   :alt: Odoo Community Association
+   :target: https://www.adhoc.com.ar
+
+This module is maintained by the ADHOC SA.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/partner_vat_unique/__openerp__.py
+++ b/partner_vat_unique/__openerp__.py
@@ -22,11 +22,6 @@
     'name': 'Partner VAT unique',
     'version': '9.0.1.0.0',
     'category': 'ADHOC Modules',
-    'description': """
-Partner VAT Unique
-==================
-Add a constraint on partners so that vat must be unique except in partner with parent/child relationship.
-    """,
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',
@@ -41,7 +36,7 @@ Add a constraint on partners so that vat must be unique except in partner with p
     ],
     'test': [
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': False,
     'application': False,
 }

--- a/partner_vat_unique/partner.py
+++ b/partner_vat_unique/partner.py
@@ -37,7 +37,7 @@ class res_partner(models.Model):
                 raise Warning(_(
                     'Partner vat must be unique per company except on partner'
                     ' with parent/childe relationship. Partners with same '
-                    'vat and not related, are: %s!') % (', '.join(x.name
-                                                                  for x in same_vat_partners)))
+                    'vat and not related, are:'
+                    ' %s!') % (', '.join(x.name for x in same_vat_partners)))
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/partner_vat_unique/partner.py
+++ b/partner_vat_unique/partner.py
@@ -35,8 +35,9 @@ class res_partner(models.Model):
                 ])
             if same_vat_partners:
                 raise Warning(_(
-                    'Partner vat must be unique per company except on partner with parent/childe relationship. '
-                    'Partners with same vat and not related, '
-                    'are: %s!') % (', '.join(x.name for x in same_vat_partners)))
+                    'Partner vat must be unique per company except on partner'
+                    ' with parent/childe relationship. Partners with same '
+                    'vat and not related, are: %s!') % (', '.join(x.name
+                                                                  for x in same_vat_partners)))
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/partner_vat_unique/partner.py
+++ b/partner_vat_unique/partner.py
@@ -35,6 +35,8 @@ class res_partner(models.Model):
                 ])
             if same_vat_partners:
                 raise Warning(_(
-                    'Partner vat must be unique per company except on partner with parent/childe relationship. Partners with same vat and not related, are: %s!') % (', '.join(x.name for x in same_vat_partners)))
+                    'Partner vat must be unique per company except on partner with parent/childe relationship. '
+                    'Partners with same vat and not related, '
+                    'are: %s!') % (', '.join(x.name for x in same_vat_partners)))
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:


### PR DESCRIPTION
Add a constraint on partners so that vat must be unique except in
partner with parent/child relationship.
