### PR TITLE
[FIX] partner_state: Problem with comercial fields

### DIFF
--- a/partner_state/models/res_partner.py
+++ b/partner_state/models/res_partner.py
@@ -44,14 +44,21 @@ class ResPartner(models.Model):
                                      ['approved', 'pending']):
             partner_block_fields = ResPartnerStateField.search(
                 [('block_edition', '=', True)]).mapped('field_id.name')
-            for key in vals.keys():
+            modified_fields = vals.keys()
+            # if it's a contact we only check the none commercial fields to
+            # allow them to be synchronized from parent
+            if partner.commercial_partner_id != partner:
+                modified_fields = list(
+                    set(modified_fields) - set(self._commercial_fields()))
+
+            for key in modified_fields:
                 if key in partner_block_fields:
                     raise UserError(
                         _('You can not modify this field "%s"' % (key)))
             fields = partner.check_fields('track')
             if fields:
                 fields_set = set(fields)
-                vals_set = set(vals)
+                vals_set = set(modified_fields)
                 if fields_set & vals_set:
                     partner.partner_state_potential()
 


### PR DESCRIPTION
If you change in a parent who has childs and one of them has the stated approve, and you modify some of the commercial fields of the parent, odoo sync the fields of the child related.
Now only control the modification fields if the comercial partner has the same as the partner