### PR TITLE
[FIX] partner_internal_code: error vals not defined

### DIFF
--- a/partner_internal_code/models/res_partner.py
+++ b/partner_internal_code/models/res_partner.py
@@ -19,7 +19,7 @@ class Partner(models.Model):
         for vals in vals_list:
             if not vals.get('internal_code'):
                 vals['internal_code'] = self.env['ir.sequence'].next_by_code('partner.internal.code')
-        return super().create(vals)
+        return super().create(vals_list)
 
     _sql_constraints = {
         ('internal_code_uniq', 'unique(internal_code)',


### PR DESCRIPTION
runbot traceback before this pr
```
[odoo.modules.registry:118](https://github.com/adhoc-cicd/odoo-odoo/blob/a9071962031458fb8f1c4eadbd6d0cbecb263625/odoo/modules/registry.py#L118)
Failed to load registry
Traceback (most recent call last):
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/tools/convert.py", line 556, in _tag_root
    f(rec)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/tools/convert.py", line 456, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/models.py", line 5061, in _load_records
    records = self._load_records_create([data['values'] for data in to_create])
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/models.py", line 4972, in _load_records_create
    return self.create(values)
  File "<decorator-gen-392>", line 2, in create
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/api.py", line 415, in _model_create_multi
    return create(self, arg)
  File "/data/build/adhoc-cicd-odoo-odoo/addons/hr/models/hr_employee.py", line 387, in create
    employees.filtered(lambda e: not e.work_contact_id).sudo()._create_work_contacts()
  File "/data/build/adhoc-cicd-odoo-odoo/addons/hr/models/hr_employee_base.py", line 204, in _create_work_contacts
    work_contacts = self.env['res.partner'].create([{
  File "<decorator-gen-138>", line 2, in create
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/api.py", line 415, in _model_create_multi
    return create(self, arg)
  File "/data/build/ingadhoc-partner/partner_internal_code/models/res_partner.py", line 22, in create
    return super().create(vals)
UnboundLocalError: local variable 'vals' referenced before assignment
```