### PR TITLE
[FIX]partner_creation_access: skip access right check when creating partner from public user

### DIFF
--- a/partner_creation_access/README.rst
+++ b/partner_creation_access/README.rst
@@ -15,6 +15,7 @@ Partner Creation Access
 =======================
 
 This module introduces a new access rule to allow users to create partners only with the 'Create Contact' access.
+Only the public user doesn't apply to this rule, so it can create partners without any access.
 
 Installation
 ============

--- a/partner_creation_access/models/res_partner.py
+++ b/partner_creation_access/models/res_partner.py
@@ -7,7 +7,9 @@ class ResPartner(models.Model):
 
     @api.model_create_multi
     def create(self, vals):
-        if not self.env.user.has_group("base.group_partner_manager"):
+        if not self.env.user.has_group("base.group_partner_manager") and not self.env.user.has_group(
+            "base.group_public"
+        ):
             raise UserError(
                 "You don't have access to create contacts. Only users with the 'Contact Creation' access can do it."
             )


### PR DESCRIPTION
When creating a partner from the contact form in website, the public user user may not have the necessary access rights to create a partner. This commit skips the access right check when creating a partner from the contact form, allowing users to create partners without encountering an access error.