### PR TITLE
[IMP]partner_creation_access: Add access rule to edit contacts

### DIFF
--- a/partner_creation_access/README.rst
+++ b/partner_creation_access/README.rst
@@ -16,6 +16,7 @@ Partner Creation Access
 
 This module introduces a new access rule to allow users to create partners only with the 'Create Contact' access.
 Only the public user doesn't apply to this rule, so it can create partners without any access.
+Also allows users with sales user access to edit partners and send messages/notes, but not to create contacts.
 
 Installation
 ============

--- a/partner_creation_access/__manifest__.py
+++ b/partner_creation_access/__manifest__.py
@@ -19,13 +19,15 @@
 ##############################################################################
 {
     "name": "Partner Creation Access",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "category": "Partner",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",
-    "depends": ["base", "contacts"],
-    "data": [],
+    "depends": ["base", "contacts", "sale"],
+    "data": [
+        "security/ir.model.access.csv",
+    ],
     "installable": True,
     "auto_install": False,
     "application": False,

--- a/partner_creation_access/security/ir.model.access.csv
+++ b/partner_creation_access/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_res_partner,res.partner.no.creation.user,base.model_res_partner,sales_team.group_sale_salesman,1,1,0,0


### PR DESCRIPTION
Add access rule to allow users with sales user access to edit partners and send messages/notes, but not to create contacts.